### PR TITLE
Turned 'shell' param variable into a class parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
-class crontab inherits crontab::params
-{
+class crontab (
+    $shell = $crontab::params::shell
+) inherits crontab::params {  
 	if $osfamily != 'Debian' {
 		fail("Unsupported platform: ${osfamily}/${operatingsystem}")
 	}

--- a/templates/job.erb
+++ b/templates/job.erb
@@ -2,7 +2,7 @@
 ### This file is managed by Puppet, and is refreshed regularly. Do not edit manually! ###
 #########################################################################################
 
-SHELL=<%=scope.lookupvar('crontab::params::shell')%>
+SHELL=<%=scope.lookupvar('crontab::shell')%>
 PATH=<%=scope.lookupvar('crontab::params::envpath').join(':')%>
 <% @env.each do |val| -%>
 <%=val%>


### PR DESCRIPTION
Because I run commands in Python virtualenvs I need my cronjobs to be executed using bash instead of sh, as virtualenvs cannot be activated in sh.

In order to be able to override the shell variable via Hiera, I turned it into a class parameter. The value can now be overridden in Hiera with `crontab::shell`.
