### PR TITLE
Fix Puppet 4 and Facter 3 Compatibility

### DIFF
--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -3,7 +3,7 @@ define crontab::daily(
 	$hour    = 0,
 	$minute  = 0,
 	$user    = 'root',
-	$mode    = 0755,
+	$mode    = '0755',
 	$env     = [],
     $stdout  = '/dev/null',
     $stderr  = '/dev/null',

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -2,7 +2,7 @@ define crontab::hourly(
 	$ensure = present,
 	$minute = 0,
 	$user   = 'root',
-	$mode   = 0755,
+	$mode   = '0755',
 	$env    = [],
     $stdout = '/dev/null',
     $stderr = '/dev/null',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,15 +12,15 @@ class crontab inherits crontab::params
 	service {'crontab::service::run':
 		ensure  => running,
 		name    => $crontab::params::service,
-		require => Package[$crontab::params::package],
+		require => Package['crontab::package::install'],
 	}
 
 	file {$crontab::params::confpath:
 		ensure  => present,
 		owner   => root,
 		group   => root,
-		mode    => 0644,
+		mode    => '0644',
 		content => template('crontab/crontab.erb'),
-		require => Package[$crontab::params::package],
+		require => Package['crontab::package::install'],
 	}
 }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -6,7 +6,7 @@ define crontab::job(
 	$month    = '*',
 	$weekday  = '*',
 	$user     = 'root',
-	$mode     = 0755,
+	$mode     = '0755',
 	$env      = [],
 	$stdout   = '/dev/null',
 	$stderr   = '/dev/null',

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -4,7 +4,7 @@ define crontab::monthly(
 	$hour   = 0,
 	$minute = 0,
 	$user   = 'root',
-	$mode   = 0755,
+	$mode   = '0755',
 	$env    = [],
     $stdout = '/dev/null',
     $stderr = '/dev/null',

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -4,7 +4,7 @@ define crontab::weekly(
 	$hour   = 0,
 	$minute = 0,
 	$user   = 'root',
-	$mode   = 0755,
+	$mode   = '0755',
 	$env    = [],
     $stdout = '/dev/null',
     $stderr = '/dev/null',


### PR DESCRIPTION
Puppet 4 file mode requires string values.
